### PR TITLE
fix pr/247

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ These rules enforce some of the [best practices recommended for using Cypress](h
 | [no-force](docs/rules/no-force.md)                                       | disallow using `force: true` with action commands          |    |
 | [no-pause](docs/rules/no-pause.md)                                       | disallow using `cy.pause()` calls                          |    |
 | [no-unnecessary-waiting](docs/rules/no-unnecessary-waiting.md)           | disallow waiting for arbitrary time periods                | ✅  |
-| [no-xpath](docs/rules/no-xpath.md)                                       | disallow usage of xpath in selector                        |    |
+| [no-xpath](docs/rules/no-xpath.md)                                       | disallow using `cy.xpath()` calls                          |    |
 | [require-data-selectors](docs/rules/require-data-selectors.md)           | require `data-*` attribute selectors                       |    |
 | [unsafe-to-chain-command](docs/rules/unsafe-to-chain-command.md)         | disallow actions within chains                             | ✅  |
 

--- a/docs/rules/no-xpath.md
+++ b/docs/rules/no-xpath.md
@@ -2,28 +2,24 @@
 
 <!-- end auto-generated rule header -->
 
-This rule disallow the usage of cypress-xpath for selecting elements.
+This rule disallows the usage of `cy.xpath()` for selecting elements.
 
+## Rule Details
 
 Examples of **incorrect** code for this rule:
 
 ```js
-
 cy.xpath('//div[@class=\"container\"]').click()
 ```
 
 Examples of **correct** code for this rule:
 
-
 ```js
-
 cy.get('[data-cy="container"]').click();
 ```
 
-
 ## Further Reading
 
-Both `@cypress/xpath` and `cypress-xpath` packages have been deprecated since Oct 13, 2022.
-
+Both `@cypress/xpath` and `cypress-xpath` are deprecated.
 
 See [the Cypress Best Practices guide](https://docs.cypress.io/guides/references/best-practices.html#Selecting-Elements).

--- a/lib/rules/no-xpath.js
+++ b/lib/rules/no-xpath.js
@@ -4,15 +4,15 @@ module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
-      description: "disallow using cy.xpath() calls",
+      description: 'disallow using `cy.xpath()` calls',
       recommended: false,
-      url: "https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-xpath.md"
+      url: 'https://github.com/cypress-io/eslint-plugin-cypress/blob/master/docs/rules/no-xpath.md'
     },
     fixable: null, // Or `code` or `whitespace`
     schema: [], // Add a schema if the rule has options
     messages: {
-      unexpected: 'avoid using cypress xpath',
-    }, 
+      unexpected: 'Avoid using cy.xpath command',
+    },
   },
 
   create (context) {

--- a/tests/lib/rules/no-xpath.js
+++ b/tests/lib/rules/no-xpath.js
@@ -14,7 +14,6 @@ const rule = require("../../../lib/rules/no-xpath"),
 const ruleTester = new RuleTester();
 ruleTester.run("no-xpath", rule, {
   valid: [
-    { code: 'cy.wait("@someRequest")' },
     { code: 'cy.get("button").click({force: true})' },
   ],
 


### PR DESCRIPTION
- Use `cy.xpath()` consistently
- Ensure documentation matches source
- Correct grammar
- Remove extra blank lines and trailing whitespace
- Make use of quotes consistent
- Remove deprecation date (only true for the older npm package)
- Remove `cy.wait()` as example of correct code, since it is unrelated

Main PR is
- https://github.com/cypress-io/eslint-plugin-cypress/pull/247